### PR TITLE
Use unique Maptiler API key

### DIFF
--- a/src/lib/Map.svelte
+++ b/src/lib/Map.svelte
@@ -333,9 +333,7 @@
     // It's bound to the `prerender` event on `overlayLayer`
     mapState.layers.overlay.olLayer.on("prerender", function (event) {
       if (mapState.viewMode === "opacity") {
-        mapState.layers.overlay.olLayer.setOpacity(
-          opacitySliderValue/100
-        );
+        mapState.layers.overlay.olLayer.setOpacity(opacitySliderValue / 100);
       } else {
         mapState.layers.overlay.olLayer.setOpacity(1);
         const ctx = event.context;
@@ -462,12 +460,17 @@
   <div
     id="opacity-control-holder"
     class="absolute top-2 right-2 w-1/3 bg-gray-50 p-2 rounded {mapState.viewMode ===
-      'opacity'
-        ? ''
-        : 'hidden'}"
+    'opacity'
+      ? ''
+      : 'hidden'}"
   >
-  <input id="default-range" type="range" bind:value={opacitySliderValue} class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-pink-900">
-  <div class="text-sm font-semibold">Opacity {opacitySliderValue}%</div>
+    <input
+      id="default-range"
+      type="range"
+      bind:value={opacitySliderValue}
+      class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-pink-900"
+    />
+    <div class="text-sm font-semibold">Opacity {opacitySliderValue}%</div>
   </div>
 
   <div
@@ -584,5 +587,4 @@
   #drag-handle {
     position: absolute;
   }
-
 </style>


### PR DESCRIPTION
@emilyrbowe @itspangler I noticed that our Maptiler costs (for the modern base map tile service) were way higher in the last billing period — which is good, it means tons of people are using Atlascope! For analytics purposes, however, I wanted to make Atlascope its own API key, so that we can track how many tile requests are coming for Atlascope relative to our other web services that use Maptiler keys. I've done that here so this should be a pretty easy PR to approve.

See below for usage graph on the main Maptiler key:

<img width="968" alt="Screenshot 2023-01-30 at 12 08 02 PM" src="https://user-images.githubusercontent.com/2424901/215545568-f7e9e646-9e34-4eda-86f5-009357d2c3f9.png">
