### PR TITLE
add sponsor an atlas links

### DIFF
--- a/src/config/instance.json
+++ b/src/config/instance.json
@@ -56,6 +56,14 @@
         "domain": "db.us.fauna.com"
     },
     "aboutPage": "https://www.leventhalmap.org/projects/digital-projects/atlascope/",
+    "outOfBoundsMessage": {
+        "url": "https://www.leventhalmap.org/donate/sponsor-an-atlas/",
+        "text": "Help us extend the coverage in Atlascope by sponsoring an atlas"
+    },
+    "splashPageNoteMessage": {
+        "url": "https://www.leventhalmap.org/donate/sponsor-an-atlas/",
+        "text": "Help us extend the coverage in Atlascope by sponsoring an atlas"
+    },
     "gaMeasurementId": "G-5K9LGW88CS",
     "metaTags": {
         "title": "Atlascope Boston",

--- a/src/lib/MapControls.svelte
+++ b/src/lib/MapControls.svelte
@@ -121,8 +121,8 @@
       <Fa icon={faExclamationCircle} class="inline mr-0.5" /> You're looking at a
       location where no historic atlas layers are currently available.
       <p class="font-light text-sm">
-        <a href="./#"
-          >Learn more about our plans for adding coverage to Atlascope.</a
+        <a href="{instanceVariables.outOfBoundsMessage.url}" target="_blank" rel="noreferrer"
+          >{instanceVariables.outOfBoundsMessage.text}</a
         >
       </p>
     </div>

--- a/src/lib/Splash.svelte
+++ b/src/lib/Splash.svelte
@@ -122,6 +122,16 @@
       }} />
 
     </div>
+    {#if instanceVariables.splashPageNoteMessage}
+    <div class="mt-2">
+      <p>
+        <a href="{instanceVariables.splashPageNoteMessage.url}" target="_blank" class="text-sm font-semibold ">
+          {instanceVariables.splashPageNoteMessage.text}
+    </a>
+      </p>
+
+    </div>
+    {/if}
   </div>
 </section>
 


### PR DESCRIPTION
This adds links to the sponsor an atlas page on the splash screen and in the modal that shows when you are in an area with no atlas coverage. Text and URLs are defined in `instance.json` and not in components.