### PR TITLE
fixing url copying error

### DIFF
--- a/src/lib/ShareLinks.svelte
+++ b/src/lib/ShareLinks.svelte
@@ -19,9 +19,15 @@
   function copyURL() {
     urlField.select();
     urlField.setSelectionRange(0, 99999);
-    navigator.clipboard.writeText(urlField.value);
     let messageSuffix = showView ? "This link will take someone to exact view you're looking at now." : "This link will take someone to the Atlascope app landing page.";
-    window.alert(`Link copied to clipboard! ${messageSuffix}`)
+    navigator.clipboard
+      .writeText(urlField.value)
+      .then(() => {
+        window.alert(`Link copied to clipboard! ${messageSuffix}`)
+      })
+      .catch(() => {
+        alert("We're sorry — something went wrong in copying this URL.");
+      });
   }
   
 </script>

--- a/src/lib/ShareLinks.svelte
+++ b/src/lib/ShareLinks.svelte
@@ -19,7 +19,7 @@
   function copyURL() {
     urlField.select();
     urlField.setSelectionRange(0, 99999);
-    let messageSuffix = showView ? "This link will take someone to exact view you're looking at now." : "This link will take someone to the Atlascope app landing page.";
+    let messageSuffix = showView ? "This link will take someone to the exact view you're looking at now." : "This link will take someone to the Atlascope app landing page.";
     navigator.clipboard
       .writeText(urlField.value)
       .then(() => {


### PR DESCRIPTION
The "copy link" button wasn't working for Mica as she's working on an Atlascope tour, so I took a look and it seemed like the `navigator.clipboard.writeText()` function wasn't written in a way where it waited for the promise to be returned. 

https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText

Slightly tweaked the code so that the copying works. 