### PR TITLE
update orthos to 2023 and change date of streets layer to 2024

### DIFF
--- a/src/config/instance.json
+++ b/src/config/instance.json
@@ -28,7 +28,7 @@
                 "globalExtent": true,
                 "identifier": "maptiler-streets",
                 "fallbackSubtitle": "Modern Streets",
-                "year": 2022,
+                "year": 2024,
                 "bibliographicEntry": "Modern street map data, [© MapTiler](https://www.maptiler.com/copyright/) and [© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)",
                 "source": {
                     "hidden": true,
@@ -40,13 +40,13 @@
         {
             "properties": {
                 "globalExtent": true,
-                "identifier": "massgis-2021-orthos",
+                "identifier": "massgis-2023-orthos",
                 "fallbackSubtitle": "Aerial Imagery",
-                "year": 2021,
-                "bibliographicEntry": "Aerial imagery of Massachusetts from 2021, provided by [MassGIS](https://www.mass.gov/info-details/massgis-data-2021-aerial-imagery)",
+                "year": 2023,
+                "bibliographicEntry": "Aerial imagery of Massachusetts from 2023, provided by [MassGIS](https://www.mass.gov/info-details/massgis-data-2023-aerial-imagery)",
                 "source": {
                     "type": "xyz",
-                    "url": "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/orthos2021/MapServer/tile/{z}/{y}/{x}"
+                    "url": "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/orthos2023/MapServer/tile/{z}/{y}/{x}"
                 }
             }
         }


### PR DESCRIPTION
MassGIS just released their 2023 ortho imagery, so I've updated the ortho layer to use that. While I was at it, I also updated the date field on the MapTiler layer to show 2024 rather than 2022.