### PR TITLE
fixes multiple point drop

### DIFF
--- a/src/lib/Map.svelte
+++ b/src/lib/Map.svelte
@@ -153,6 +153,7 @@
 
     if (options.dropMarkerAtPoint) {
       const targetPoint = fromLonLat(options.center);
+      markerGeometrySource.clear();
       markerGeometrySource.addFeature(
         new Feature({ geometry: new Point(targetPoint) })
       );


### PR DESCRIPTION
This fixes a minor bug (not yet noted in Issues) where searching multiple addresses, or using browser geolocation multiple times, resulted in additional pins being added to the map. This fix deletes all previous pins each time someone executes an address search or browser geolocation action.