### PR TITLE
reimplement tour loading from url

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,7 +19,6 @@
 
   import { mapState, appState, allLayers } from "./lib/state.svelte.js";
 
-
   // Initialization functions; parse out the initial url params and fetch the layer data
   onMount(() => {
     const urlParams = parseUrlParams(
@@ -48,7 +47,9 @@
     if (urlParams.view && urlParams.view === "share") {
       appState.modals.splash = false;
     } else if (urlParams.view && urlParams.view === "tour") {
-      return;
+      appState.tour.id = urlParams.tour;
+      appState.tour.active = true;
+      appState.modals.splash = false;
     }
   });
 </script>
@@ -70,14 +71,12 @@
     <TourController />
   {/if}
 
-  {#if appState.modals.splash || appState.modals.search || appState.modals.biblio || appState.modals.tourList }
-  <ModalWrapper />
+  {#if appState.modals.splash || appState.modals.search || appState.modals.biblio || appState.modals.tourList}
+    <ModalWrapper />
   {/if}
-
 </div>
 
 <style>
-
   :global(body) {
     font-family: "Inter Variable", sans-serif;
     overflow: hidden;

--- a/src/config/instance.json
+++ b/src/config/instance.json
@@ -28,14 +28,13 @@
         {
             "properties": {
                 "globalExtent": true,
-                "identifier": "maptiler-streets",
-                "fallbackSubtitle": "Modern Streets",
-                "year": 2024,
-                "bibliographicEntry": "Modern street map data, [© MapTiler](https://www.maptiler.com/copyright/) and [© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)",
+                "identifier": "massgis-1990s-orthos",
+                "fallbackSubtitle": "Aerial Imagery",
+                "year": 1995,
+                "bibliographicEntry": "Aerial imagery of Massachusetts from the 1990s, provided by [MassGIS](https://www.mass.gov/info-details/massgis-data-1990s-aerial-imagery)",
                 "source": {
-                    "hidden": true,
-                    "type": "tilejson",
-                    "url": "https://api.maptiler.com/maps/streets/tiles.json?key=DY88zutnCSJjg1OmMrUF"
+                    "type": "xyz",
+                    "url": "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/BW_Orthos_Tile_Package/MapServer/tile/{z}/{y}/{x}"
                 }
             }
         },
@@ -62,6 +61,20 @@
                 "source": {
                     "type": "xyz",
                     "url": "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/orthos2023/MapServer/tile/{z}/{y}/{x}"
+                }
+            }
+        },
+        {
+            "properties": {
+                "globalExtent": true,
+                "identifier": "maptiler-streets",
+                "fallbackSubtitle": "Modern Streets",
+                "year": 2025,
+                "bibliographicEntry": "Modern street map data, [© MapTiler](https://www.maptiler.com/copyright/) and [© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)",
+                "source": {
+                    "hidden": true,
+                    "type": "tilejson",
+                    "url": "https://api.maptiler.com/maps/streets/tiles.json?key=DY88zutnCSJjg1OmMrUF"
                 }
             }
         }


### PR DESCRIPTION
@itspangler I realized I had disabled the logic that switches into tour mode when loading from a `view:tour` URL. This small change re-implements that behavior.