### PR TITLE
Rebuild research connectors: search + data-loading dropups

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -9,6 +9,15 @@
         "export PATH=\"$HOME/.nvm/versions/node/v22.13.0/bin:$PATH\" && npm run dev"
       ],
       "port": 5173
+    },
+    {
+      "name": "dev-netlify",
+      "runtimeExecutable": "zsh",
+      "runtimeArgs": [
+        "-c",
+        "export PATH=\"$HOME/.nvm/versions/node/v22.13.0/bin:$PATH\" && npm run dev:netlify"
+      ],
+      "port": 8888
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 .cursorrules
 .env
+# Local Netlify folder
+.netlify
+deno.lock

--- a/FORKING.md
+++ b/FORKING.md
@@ -83,6 +83,61 @@ The Supabase project needs a `tours` table (`id`, `published`,
 `email`). With both features off, no Supabase client is ever created and the
 supabase-js chunk is never fetched.
 
+### Map image sharing (`ExportShareButton`)
+
+`src/lib/mapControls/ExportShareButton.svelte` composites the map to a PNG,
+writes it to an S3-compatible bucket, and opens an outbound URL built from the
+stored object's random hash. Two props:
+
+- `urlTemplate` — the URL to open, with `{hash}` standing in for the stored
+  filename. Pass it as a JS string — `urlTemplate={"https://example.org/view/{hash}"}`
+  — not as a bare attribute, since Svelte reads `{hash}` in attribute position
+  as an interpolation.
+- `label` — the button text.
+
+Optional: `icon` (defaults to a camera), `busyLabel`, `collapsibleLabel`,
+`hideableOnMobile`. Because the template is a prop rather than instance config,
+the same button can be dropped in more than once pointing at different
+services. `MapControls.svelte` has a working example in the Controls tab.
+
+The upload is signed by `netlify/functions/sign-image-upload.js`, so these are
+**server-side** variables (set in the Netlify UI, not `VITE_`-prefixed — they
+must never reach the browser bundle):
+
+- `WASABI_ACCESS_KEY_ID`
+- `WASABI_SECRET_ACCESS_KEY`
+- `WASABI_REGION` — e.g. `us-east-2`
+- `WASABI_BUCKET`
+- `WASABI_PREFIX` — directory the images are written under
+- `ALLOWED_ORIGINS` — optional comma-separated origin allowlist, e.g.
+  `https://atlascope.org,http://localhost:8888`
+
+Unset any of the first five and the button fails with a message rather than
+half-working. Shift+Alt+E, which downloads the same composited PNG instead of
+uploading it, is unaffected and needs no configuration.
+
+The endpoint is unauthenticated, so the credential should be scoped to
+`s3:PutObject` on `<bucket>/<prefix>/*` only — no `ListBucket`, no
+`DeleteObject`, no access outside the prefix. `ALLOWED_ORIGINS` is a speed bump,
+not security. The function, not the browser, picks the object key, so callers
+can't overwrite existing objects.
+
+The bucket also needs a CORS rule, or the browser's PUT dies at the preflight:
+
+```xml
+<CORSConfiguration>
+  <CORSRule>
+    <AllowedOrigin>https://atlascope.org</AllowedOrigin>
+    <AllowedOrigin>http://localhost:8888</AllowedOrigin>
+    <AllowedMethod>PUT</AllowedMethod>
+    <AllowedHeader>Content-Type</AllowedHeader>
+  </CORSRule>
+</CORSConfiguration>
+```
+
+Local development needs `npx netlify dev` (port 8888) rather than `npm run dev`,
+since `vite` alone doesn't serve the function.
+
 ## 4. Hosted data files
 
 The three URLs in `instance.json` point at data you host (S3 or similar):

--- a/FORKING.md
+++ b/FORKING.md
@@ -38,11 +38,37 @@ Every instance-specific value lives here.
 
 ## 2. `src/config/research-connections.js`
 
-External bbox-driven search links shown in the Research tab. Each entry has a
-`name`, a `searchFunction(bbox)` returning a URL, and `hiddenOnMobile`.
-Replace the Boston/Massachusetts entries (Digital Commonwealth, MassMapper)
-with your region's equivalents, or export an empty array. When the array is
-empty **and** annotations are disabled, the Research tab is hidden.
+Research-tab connectors, exported as **two** arrays.
+
+`searchConnectors` — items in the "Search this location for …" dropdown. Each
+opens an external web app for the current map view. Fields:
+
+- `name` — dropdown label.
+- `queryType` — `"bbox"` or `"centerpoint"`.
+- `hiddenOnMobile` — boolean.
+- `urlFunction(geo)` — returns the URL to open. `geo` is
+  `[west, south, east, north]` (EPSG:4326) when `queryType` is `"bbox"`, or
+  `[lon, lat]` (EPSG:4326) when `queryType` is `"centerpoint"`.
+
+`dataConnectors` — items in the "Load data from …" dropdown. Each fetches
+POINT data from an API and renders it as a clickable scratch layer on the map.
+Fields:
+
+- `name` — dropdown label.
+- `hiddenOnMobile` — boolean.
+- `queryUrl(bbox)` — request URL, where `bbox` is `[west, south, east, north]`
+  (EPSG:4326). The request MUST return GeoJSON (e.g. an ArcGIS FeatureServer
+  query with `f=geojson`). Only Point geometries in the response are rendered.
+- `label(props)` — returns the text label drawn on each point.
+- `targetUrl(props)` — returns the URL the point's popup links to.
+
+For both `label` and `targetUrl`, `props` is a GeoJSON feature's `properties`
+object.
+
+Replace the Boston/Massachusetts entries (Digital Commonwealth, MassMapper,
+MACRIS) with your region's equivalents, or export an empty array to hide that
+dropdown. The Research tab is hidden only when **both** `searchConnectors` and
+`dataConnectors` are empty **and** annotations are disabled.
 
 ## 3. Environment variables (`.env`)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,11 @@
 
 [build.environment]
   NODE_VERSION = "22"
+
+# Pinned so `netlify dev` doesn't stop on an interactive prompt: both Vite and
+# Svelte match its framework detection, and it can't choose between them.
+[dev]
+  command = "npm run dev"
+  framework = "#custom"
+  targetPort = 5173
+  port = 8888

--- a/netlify/functions/sign-image-upload.js
+++ b/netlify/functions/sign-image-upload.js
@@ -1,0 +1,91 @@
+// Hands the browser a short-lived presigned S3 PUT URL so it can write a map
+// image straight to object storage. The Wasabi secret never leaves this
+// function, and the object key is generated here rather than accepted from the
+// caller — so a caller can't choose a key or overwrite an existing object.
+//
+// This endpoint is unauthenticated, which makes it a write oracle for its
+// prefix. The credential it uses should be scoped to s3:PutObject on
+// <bucket>/<prefix>/* and nothing else. ALLOWED_ORIGINS is a speed bump, not
+// security: origin headers are trivially forged.
+import { randomBytes } from "node:crypto";
+import { AwsClient } from "aws4fetch";
+
+const REQUIRED_VARS = [
+  "WASABI_ACCESS_KEY_ID",
+  "WASABI_SECRET_ACCESS_KEY",
+  "WASABI_REGION",
+  "WASABI_BUCKET",
+  "WASABI_PREFIX",
+];
+
+// Long enough to cover a slow upload of a few megabytes, short enough that a
+// leaked URL is worthless quickly.
+const EXPIRES_SECONDS = 300;
+
+function json(body, status) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export default async function handler(request) {
+  if (request.method !== "POST") {
+    return json({ error: "Method not allowed." }, 405);
+  }
+
+  const allowedOrigins = (process.env.ALLOWED_ORIGINS || "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  if (allowedOrigins.length) {
+    const origin = request.headers.get("origin");
+    if (!origin || !allowedOrigins.includes(origin)) {
+      return json({ error: "Origin not allowed." }, 403);
+    }
+  }
+
+  // Same posture as supabaseClient.js: forks without credentials configured
+  // only fail when the feature is actually used, and they fail legibly.
+  const missing = REQUIRED_VARS.filter((name) => !process.env[name]);
+  if (missing.length) {
+    console.error(`sign-image-upload is missing config: ${missing.join(", ")}`);
+    return json(
+      { error: "Image sharing isn't configured on this instance." },
+      500,
+    );
+  }
+
+  const hash = randomBytes(16).toString("hex");
+  const prefix = process.env.WASABI_PREFIX.replace(/^\/+|\/+$/g, "");
+  const key = prefix ? `${prefix}/${hash}.png` : `${hash}.png`;
+
+  const client = new AwsClient({
+    accessKeyId: process.env.WASABI_ACCESS_KEY_ID,
+    secretAccessKey: process.env.WASABI_SECRET_ACCESS_KEY,
+    // aws4fetch guesses these from the hostname, and it can't read a
+    // wasabisys.com host, so both have to be pinned explicitly.
+    service: "s3",
+    region: process.env.WASABI_REGION,
+  });
+
+  // Path-style addressing, which Wasabi supports and which sidesteps DNS
+  // propagation issues with virtual-host style on new buckets. X-Amz-Expires
+  // has to be on the URL before signing — aws4fetch reads it from there and
+  // otherwise defaults to 24 hours.
+  const target =
+    `https://s3.${process.env.WASABI_REGION}.wasabisys.com` +
+    `/${process.env.WASABI_BUCKET}/${key}` +
+    `?X-Amz-Expires=${EXPIRES_SECONDS}`;
+
+  // Content-Type is deliberately not signed (aws4fetch treats it as
+  // unsignable), so SignedHeaders is just `host`. The browser still sends
+  // Content-Type on the PUT and S3 stores it as object metadata.
+  const signed = await client.sign(target, {
+    method: "PUT",
+    aws: { signQuery: true },
+  });
+
+  return json({ hash, uploadUrl: signed.url }, 200);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@turf/boolean-point-in-polygon": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "@turf/intersect": "^7.3.5",
+        "aws4fetch": "^1.0.20",
         "ol": "^10.9.0",
         "proj4": "^2.20.9",
         "svelte-fa": "^4.0.4",
@@ -450,9 +451,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -468,9 +466,6 @@
       "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -488,9 +483,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -506,9 +498,6 @@
       "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -526,9 +515,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -544,9 +530,6 @@
       "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -877,9 +860,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -895,9 +875,6 @@
       "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -915,9 +892,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -933,9 +907,6 @@
       "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1264,6 +1235,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
@@ -1752,9 +1729,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1774,9 +1748,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -1798,9 +1769,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1820,9 +1788,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
+    "dev:netlify": "netlify dev",
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-check"
@@ -31,6 +32,7 @@
     "@turf/boolean-point-in-polygon": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "@turf/intersect": "^7.3.5",
+    "aws4fetch": "^1.0.20",
     "ol": "^10.9.0",
     "proj4": "^2.20.9",
     "svelte-fa": "^4.0.4",

--- a/src/config/research-connections.js
+++ b/src/config/research-connections.js
@@ -27,7 +27,13 @@ export const searchConnectors = [
         urlFunction: (geo) => `https://www.digitalcommonwealth.org/search?coordinates=%5B${geo[1]}%2C${geo[0]}%20TO%20${geo[3]}%2C${geo[2]}%5D&spatial_search_type=bbox&view=gallery&f%5Bgenre_basic_ssim%5D%5B%5D=Maps&spatial_search_type=bbox&view=gallery`,
     },
     {
-        name: "Historic photographs in Digital Commonwealth",
+        name: "More maps in Allmaps Explore (beta)",
+        queryType: "centerpoint",
+        hiddenOnMobile: true,
+        urlFunction: (geo) => `https://dev.explore.allmaps.org/#12/${geo[1]}/${geo[0]}`,
+    },
+    {
+        name: "Photographs in Digital Commonwealth",
         queryType: "bbox",
         hiddenOnMobile: false,
         urlFunction: (geo) => `https://www.digitalcommonwealth.org/search?coordinates=%5B${geo[1]}%2C${geo[0]}%20TO%20${geo[3]}%2C${geo[2]}%5D&spatial_search_type=bbox&view=gallery&f%5Bgenre_basic_ssim%5D%5B%5D=Photographs`,
@@ -37,12 +43,6 @@ export const searchConnectors = [
         queryType: "bbox",
         hiddenOnMobile: true,
         urlFunction: (geo) => `https://maps.massgis.digital.mass.gov/MassMapper/MassMapper.html?bl=MassGIS%20Basemap__100&l=Basemaps_L3Parcels____ON__100&b=${geo.join(",")}`,
-    },
-    {
-        name: "More maps in Allmaps Explore (beta)",
-        queryType: "centerpoint",
-        hiddenOnMobile: true,
-        urlFunction: (geo) => `https://dev.explore.allmaps.org/#12/${geo[1]}/${geo[0]}`,
     }
 ];
 

--- a/src/config/research-connections.js
+++ b/src/config/research-connections.js
@@ -54,8 +54,13 @@ export const dataConnectors = [
             `https://services1.arcgis.com/hGdibHYSPO59RG1h/arcgis/rest/services/MHC_Inventory_GDB/FeatureServer/0/query` +
             `?where=1%3D1&outFields=*&geometry=${bbox.join(",")}&geometryType=esriGeometryEnvelope` +
             `&inSR=4326&spatialRel=esriSpatialRelIntersects&outSR=4326&f=geojson`,
-        label: (props) => props.HISTORIC_N || props.COMMON_NAM || props.ADDRESS || "Unnamed resource",
-        // MHCN looks like "BOS.2624". Confirm this detail-page pattern for your instance.
+        // MACRIS returns whitespace-only strings (e.g. " ") for empty fields,
+        // which are truthy — so a plain `a || b` chain stops at the first blank
+        // field. Trim each candidate and take the first that has real content.
+        label: (props) =>
+            [props.HISTORIC_N, props.COMMON_NAM, props.ADDRESS, props.MHCN]
+                .map((v) => (typeof v === "string" ? v.trim() : ""))
+                .find((v) => v) || "Unnamed resource",
         targetUrl: (props) => `https://mhc-macris.net/details?mhcid=${props.MHCN}`,
     },
 ];

--- a/src/config/research-connections.js
+++ b/src/config/research-connections.js
@@ -1,20 +1,61 @@
-export const bboxFunctions = [
-    {
-        "name": "Search more maps here",
-        "searchFunction": function (bbox) { return `https://www.digitalcommonwealth.org/search?coordinates=%5B${bbox[1]}%2C${bbox[0]}%20TO%20${bbox[3]}%2C${bbox[2]}%5D&spatial_search_type=bbox&view=gallery&f%5Bgenre_basic_ssim%5D%5B%5D=Maps&spatial_search_type=bbox&view=gallery` },
-        "hiddenOnMobile": false
-    }
-    ,
+// Research connectors for the "Research" tab. Two kinds:
+//
+//   searchConnectors — items in the "Search this location for …" dropdown.
+//     Each builds an outbound URL to an external web app from the current map
+//     view. `queryType` selects what geometry `urlFunction` receives:
+//       "bbox"        → [west, south, east, north]  (EPSG:4326)
+//       "centerpoint" → [lon, lat]                  (EPSG:4326)
+//
+//   dataConnectors — items in the "Load data from …" dropdown. Each fetches
+//     POINT data from an API and renders it as a clickable scratch layer.
+//       queryUrl(bbox) → request URL; MUST return GeoJSON (e.g. ArcGIS f=geojson).
+//       label(props)   → text label drawn on each point (props = a GeoJSON
+//                        feature's `properties` object).
+//       targetUrl(props) → URL the point's popup links to.
+//     Only Point geometries in the response are rendered.
+//
+// This file is part of the fork-and-edit config surface (see FORKING.md §2):
+// replace the entries below with your region's equivalents, or export empty
+// arrays to hide that dropdown. When BOTH arrays are empty and annotations are
+// disabled, the Research tab is hidden entirely.
 
+export const searchConnectors = [
     {
-        "name": "Search photographs here",
-        "searchFunction": function (bbox) { return `https://www.digitalcommonwealth.org/search?coordinates=%5B${bbox[1]}%2C${bbox[0]}%20TO%20${bbox[3]}%2C${bbox[2]}%5D&spatial_search_type=bbox&view=gallery&f%5Bgenre_basic_ssim%5D%5B%5D=Photographs` },
-        "hiddenOnMobile": false
+        name: "More maps in the Leventhal collections",
+        queryType: "bbox",
+        hiddenOnMobile: false,
+        urlFunction: (geo) => `https://www.digitalcommonwealth.org/search?coordinates=%5B${geo[1]}%2C${geo[0]}%20TO%20${geo[3]}%2C${geo[2]}%5D&spatial_search_type=bbox&view=gallery&f%5Bgenre_basic_ssim%5D%5B%5D=Maps&spatial_search_type=bbox&view=gallery`,
     },
-
     {
-        "name": "Search parcels in MassMapper",
-        "searchFunction": function (bbox) { return `https://maps.massgis.digital.mass.gov/MassMapper/MassMapper.html?bl=MassGIS%20Basemap__100&l=Basemaps_L3Parcels____ON__100&b=${bbox.join(',')}` },
-        "hiddenOnMobile": true
+        name: "Historic photographs in Digital Commonwealth",
+        queryType: "bbox",
+        hiddenOnMobile: false,
+        urlFunction: (geo) => `https://www.digitalcommonwealth.org/search?coordinates=%5B${geo[1]}%2C${geo[0]}%20TO%20${geo[3]}%2C${geo[2]}%5D&spatial_search_type=bbox&view=gallery&f%5Bgenre_basic_ssim%5D%5B%5D=Photographs`,
+    },
+    {
+        name: "Tax parcels in MassMapper",
+        queryType: "bbox",
+        hiddenOnMobile: true,
+        urlFunction: (geo) => `https://maps.massgis.digital.mass.gov/MassMapper/MassMapper.html?bl=MassGIS%20Basemap__100&l=Basemaps_L3Parcels____ON__100&b=${geo.join(",")}`,
+    },
+    {
+        name: "More maps in Allmaps Explore (beta)",
+        queryType: "centerpoint",
+        hiddenOnMobile: true,
+        urlFunction: (geo) => `https://dev.explore.allmaps.org/#12/${geo[1]}/${geo[0]}`,
     }
-]
+];
+
+export const dataConnectors = [
+    {
+        name: "MACRIS historic inventory",
+        hiddenOnMobile: false,
+        queryUrl: (bbox) =>
+            `https://services1.arcgis.com/hGdibHYSPO59RG1h/arcgis/rest/services/MHC_Inventory_GDB/FeatureServer/0/query` +
+            `?where=1%3D1&outFields=*&geometry=${bbox.join(",")}&geometryType=esriGeometryEnvelope` +
+            `&inSR=4326&spatialRel=esriSpatialRelIntersects&outSR=4326&f=geojson`,
+        label: (props) => props.HISTORIC_N || props.COMMON_NAM || props.ADDRESS || "Unnamed resource",
+        // MHCN looks like "BOS.2624". Confirm this detail-page pattern for your instance.
+        targetUrl: (props) => `https://mhc-macris.net/details?mhcid=${props.MHCN}`,
+    },
+];

--- a/src/lib/Map.svelte
+++ b/src/lib/Map.svelte
@@ -22,7 +22,7 @@
   import instanceVariables from "../config/instance.json";
   import { annotationsEnabled } from "../config/features.js";
   import { mapState, appState, allLayers } from "./state.svelte.js";
-  import { registerMap, unregisterMap, reloadScratchData, clearScratchData } from "./map/mapActions.js";
+  import { registerMap, unregisterMap } from "./map/mapActions.js";
   import { createLayerSwitcher, pickBestOverlayLayer } from "./map/layerSwitching.js";
   import { createViewModeHandlers } from "./map/viewModeRendering.js";
   import { exportMapImage } from "./map/exportImage.js";
@@ -57,6 +57,10 @@
   // annotation code out of the bundle for instances that disable it
   let MapAnnotations = $state(null);
 
+  // The loaded-data badge is code-split into its own chunk, fetched on mount so
+  // it's ready by the time a research data query is triggered.
+  let DataLayerBadge = $state(null);
+
   let markerGeometrySource = new VectorSource({ wrapX: false });
   let markerLayer = new VectorLayer({
     source: markerGeometrySource,
@@ -73,10 +77,11 @@
   // Each feature carries a `_label` and `_targetUrl` (both surfaced in the
   // click popup, set in mapActions.loadScratchData). Points are unlabeled on
   // the map itself and drawn as a hand-built "+" SVG marker (white halo under
-  // a rose plus for contrast over both historic and modern basemaps).
+  // an indigo plus for contrast over both historic and modern basemaps).
+  // #4338ca is Tailwind's indigo-700, matching the data-layer badge.
   const plusIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18">
-      <circle cx="9" cy="9" r="7.25" fill="#ffffff" stroke="rgb(180,30,90)" stroke-width="1.5"/>
-      <path d="M9 5.5 V12.5 M5.5 9 H12.5" stroke="rgb(180,30,90)" stroke-width="2" stroke-linecap="round"/>
+      <circle cx="9" cy="9" r="7.25" fill="#ffffff" stroke="#4338ca" stroke-width="1.5"/>
+      <path d="M9 5.5 V12.5 M5.5 9 H12.5" stroke="#4338ca" stroke-width="2" stroke-linecap="round"/>
     </svg>`;
   let scratchSource = new VectorSource({ wrapX: false });
   let scratchLayer = new VectorLayer({
@@ -244,6 +249,10 @@
       });
     }
 
+    import("./mapControls/DataLayerBadge.svelte").then((m) => {
+      DataLayerBadge = m.default;
+    });
+
     registerMap({
       map,
       view,
@@ -304,28 +313,8 @@
     {/if}
   </div>
 
-  {#if mapState.activeDataConnectorName}
-    <div
-      class="absolute top-10 left-1/2 -translate-x-1/2 z-20 bg-white/95 text-gray-900 py-2 px-4 rounded-lg shadow-lg flex flex-col md:flex-row items-center gap-3"
-    >
-      <span class="font-semibold text-sm">
-        {mapState.scratchPointCount} point{mapState.scratchPointCount === 1
-          ? ""
-          : "s"} displayed from {mapState.activeDataConnectorName}
-      </span>
-      <button
-        class="bg-rose-700 text-white rounded px-3 py-1 text-sm font-semibold hover:bg-rose-800 cursor-pointer"
-        onclick={() => clearScratchData()}>Clear data</button
-      >
-      <button
-        class="rounded px-3 py-1 text-sm font-semibold {mapState.scratchReloadAvailable
-          ? 'bg-sky-700 text-white hover:bg-sky-800 cursor-pointer'
-          : 'bg-gray-200 text-gray-400 cursor-not-allowed'}"
-        disabled={!mapState.scratchReloadAvailable}
-        onclick={() => reloadScratchData(mapState.extent)}
-        >Reload data for this area</button
-      >
-    </div>
+  {#if DataLayerBadge}
+    <DataLayerBadge />
   {/if}
 
   <DragHandle

--- a/src/lib/Map.svelte
+++ b/src/lib/Map.svelte
@@ -306,7 +306,7 @@
 
   {#if mapState.activeDataConnectorName}
     <div
-      class="absolute top-5 left-1/2 -translate-x-1/2 z-20 bg-white/95 text-gray-900 py-2 px-4 rounded-lg shadow-lg flex items-center gap-3"
+      class="absolute top-10 left-1/2 -translate-x-1/2 z-20 bg-white/95 text-gray-900 py-2 px-4 rounded-lg shadow-lg flex flex-col md:flex-row items-center gap-3"
     >
       <span class="font-semibold text-sm">
         {mapState.scratchPointCount} point{mapState.scratchPointCount === 1

--- a/src/lib/Map.svelte
+++ b/src/lib/Map.svelte
@@ -9,18 +9,20 @@
   import "ol/ol.css";
   import { Map, View } from "ol";
   import TileLayer from "ol/layer/Tile";
+  import Overlay from "ol/Overlay";
   import { WarpedMapLayer } from "@allmaps/openlayers";
   import { fromLonLat, toLonLat, transformExtent } from "ol/proj";
   import VectorSource from "ol/source/Vector";
   import VectorLayer from "ol/layer/Vector";
   import { Fill, Stroke, Style, Circle } from "ol/style";
+  import Icon from "ol/style/Icon";
 
   import { intersector, bboxesOverlap } from "./helpers/intersector";
 
   import instanceVariables from "../config/instance.json";
   import { annotationsEnabled } from "../config/features.js";
   import { mapState, appState, allLayers } from "./state.svelte.js";
-  import { registerMap, unregisterMap } from "./map/mapActions.js";
+  import { registerMap, unregisterMap, reloadScratchData, clearScratchData } from "./map/mapActions.js";
   import { createLayerSwitcher, pickBestOverlayLayer } from "./map/layerSwitching.js";
   import { createViewModeHandlers } from "./map/viewModeRendering.js";
   import { exportMapImage } from "./map/exportImage.js";
@@ -67,6 +69,40 @@
     }),
   });
 
+  // Scratch layer holding point data loaded from a research dataConnector.
+  // Each feature carries a `_label` and `_targetUrl` (both surfaced in the
+  // click popup, set in mapActions.loadScratchData). Points are unlabeled on
+  // the map itself and drawn as a hand-built "+" SVG marker (white halo under
+  // a rose plus for contrast over both historic and modern basemaps).
+  const plusIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18">
+      <circle cx="9" cy="9" r="7.25" fill="#ffffff" stroke="rgb(180,30,90)" stroke-width="1.5"/>
+      <path d="M9 5.5 V12.5 M5.5 9 H12.5" stroke="rgb(180,30,90)" stroke-width="2" stroke-linecap="round"/>
+    </svg>`;
+  let scratchSource = new VectorSource({ wrapX: false });
+  let scratchLayer = new VectorLayer({
+    source: scratchSource,
+    style: new Style({
+      image: new Icon({
+        src: "data:image/svg+xml;utf8," + encodeURIComponent(plusIconSvg),
+      }),
+    }),
+  });
+
+  // Click popup for scratch points. `popupEl` is bound to the DOM node used by
+  // an ol/Overlay; `scratchPopup` drives its reactive content.
+  let popupEl;
+  let popupOverlay;
+  let scratchPopup = $state({ visible: false, label: "", url: "" });
+
+  // Dismiss a lingering point popup when the scratch layer is cleared — its
+  // feature no longer exists on the map.
+  $effect(() => {
+    if (!mapState.activeDataConnectorName && scratchPopup.visible) {
+      scratchPopup = { visible: false, label: "", url: "" };
+      popupOverlay?.setPosition(undefined);
+    }
+  });
+
   // Debounce timer for mapMoved function
   let mapMovedTimeout;
 
@@ -92,6 +128,13 @@
         "EPSG:4326",
       );
       mapState.extent = extent;
+
+      // Loaded scratch data never auto-refreshes; the first map move after a
+      // (re)load enables the badge's "reload data for this area" button. (A
+      // fresh load doesn't move the map, so this only fires on user navigation.)
+      if (mapState.activeDataConnectorName) {
+        mapState.scratchReloadAvailable = true;
+      }
 
       const visibility = {};
       allLayers.layers.forEach((lyr) => {
@@ -143,7 +186,36 @@
         warpedLayers.base,
         olLayers.overlay,
         markerLayer,
+        scratchLayer,
       ],
+    });
+
+    // Popup overlay for scratch points, and a click handler that shows it when
+    // a scratch feature is hit (and dismisses it on an empty click).
+    popupOverlay = new Overlay({
+      element: popupEl,
+      positioning: "bottom-center",
+      offset: [0, -12],
+      stopEvent: true,
+    });
+    map.addOverlay(popupOverlay);
+
+    map.on("singleclick", (evt) => {
+      const feature = map.forEachFeatureAtPixel(evt.pixel, (f) => f, {
+        layerFilter: (l) => l === scratchLayer,
+        hitTolerance: 6,
+      });
+      if (feature) {
+        scratchPopup = {
+          visible: true,
+          label: feature.get("_label") || "",
+          url: feature.get("_targetUrl") || "",
+        };
+        popupOverlay.setPosition(evt.coordinate);
+      } else if (scratchPopup.visible) {
+        scratchPopup = { visible: false, label: "", url: "" };
+        popupOverlay.setPosition(undefined);
+      }
     });
 
     changeLayer("base", mapState.layers.base.id, true);
@@ -176,6 +248,7 @@
       map,
       view,
       markerSource: markerGeometrySource,
+      scratchSource,
       changeLayer,
       warpedLayers,
       olLayers,
@@ -204,6 +277,56 @@
 
 <section id="map">
   <div id="map-div"></div>
+
+  <div
+    bind:this={popupEl}
+    class="scratch-popup {scratchPopup.visible ? '' : 'hidden'}"
+  >
+    {#if scratchPopup.visible}
+      <button
+        class="scratch-popup-close"
+        aria-label="Close"
+        onclick={() => {
+          scratchPopup = { visible: false, label: "", url: "" };
+          popupOverlay.setPosition(undefined);
+        }}>×</button
+      >
+      {#if scratchPopup.url}
+        <a
+          href={scratchPopup.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-blue-700 font-semibold hover:underline">{scratchPopup.label}</a
+        >
+      {:else}
+        <span class="font-semibold text-gray-900">{scratchPopup.label}</span>
+      {/if}
+    {/if}
+  </div>
+
+  {#if mapState.activeDataConnectorName}
+    <div
+      class="absolute top-5 left-1/2 -translate-x-1/2 z-20 bg-white/95 text-gray-900 py-2 px-4 rounded-lg shadow-lg flex items-center gap-3"
+    >
+      <span class="font-semibold text-sm">
+        {mapState.scratchPointCount} point{mapState.scratchPointCount === 1
+          ? ""
+          : "s"} displayed from {mapState.activeDataConnectorName}
+      </span>
+      <button
+        class="bg-rose-700 text-white rounded px-3 py-1 text-sm font-semibold hover:bg-rose-800 cursor-pointer"
+        onclick={() => clearScratchData()}>Clear data</button
+      >
+      <button
+        class="rounded px-3 py-1 text-sm font-semibold {mapState.scratchReloadAvailable
+          ? 'bg-sky-700 text-white hover:bg-sky-800 cursor-pointer'
+          : 'bg-gray-200 text-gray-400 cursor-not-allowed'}"
+        disabled={!mapState.scratchReloadAvailable}
+        onclick={() => reloadScratchData(mapState.extent)}
+        >Reload data for this area</button
+      >
+    </div>
+  {/if}
 
   <DragHandle
     bind:dragXY
@@ -255,5 +378,43 @@
     width: 100%;
     height: 100%;
     margin: 0;
+  }
+
+  .scratch-popup {
+    position: relative;
+    background: white;
+    padding: 8px 26px 8px 12px;
+    border-radius: 6px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+    max-width: 240px;
+    font-size: 0.875rem;
+    line-height: 1.2;
+  }
+
+  .scratch-popup::after {
+    content: "";
+    position: absolute;
+    bottom: -7px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-left: 7px solid transparent;
+    border-right: 7px solid transparent;
+    border-top: 7px solid white;
+  }
+
+  .scratch-popup-close {
+    position: absolute;
+    top: 2px;
+    right: 6px;
+    border: none;
+    background: none;
+    font-size: 1rem;
+    line-height: 1;
+    color: #6b7280;
+    cursor: pointer;
+  }
+
+  .scratch-popup-close:hover {
+    color: #111827;
   }
 </style>

--- a/src/lib/map/DragHandle.svelte
+++ b/src/lib/map/DragHandle.svelte
@@ -81,11 +81,18 @@
     window.addEventListener("mouseup", stopDragging);
     window.addEventListener("touchend", stopDragging);
 
+    // Suppress text selection across the whole document while dragging — the
+    // window-level move listeners otherwise let the browser drag-select text
+    // on elements the pointer passes over.
+    const prevUserSelect = document.body.style.userSelect;
+    document.body.style.userSelect = "none";
+
     return () => {
       window.removeEventListener("mousemove", manipulateDrag);
       window.removeEventListener("touchmove", manipulateDrag);
       window.removeEventListener("mouseup", stopDragging);
       window.removeEventListener("touchend", stopDragging);
+      document.body.style.userSelect = prevUserSelect;
     };
   });
 </script>
@@ -97,7 +104,10 @@
     ? 'hidden'
     : ''}"
   style="left: {dragXY[0]}px; top: {dragXY[1]}px"
-  onmousedown={() => {
+  onmousedown={(e) => {
+    // Stop the browser from starting a text selection on mousedown; the
+    // window-level move listener would otherwise extend it across the page.
+    e.preventDefault();
     draggingFlag = true;
   }}
   ontouchstart={() => {

--- a/src/lib/map/exportImage.js
+++ b/src/lib/map/exportImage.js
@@ -1,61 +1,152 @@
-// Composites the map's layer canvases into a single PNG and triggers a
-// download. Bound to Shift+Alt+E in Map.svelte.
-export function exportMapImage(map) {
-  if (!map) return;
+// Flattens the map's layer canvases into a single PNG. Two consumers:
+// exportMapImage downloads the file (Shift+Alt+E in Map.svelte), and
+// uploadMapImage writes it to object storage and returns a share URL built
+// from the storage key (reached through shareMapImage in mapActions.js, which
+// is what ExportShareButton calls).
 
-  map.once("rendercomplete", function () {
-    const size = map.getSize();
-    if (!size) return;
+const SIGN_ENDPOINT = "/.netlify/functions/sign-image-upload";
 
-    const exportCanvas = document.createElement("canvas");
-    const [width, height] = size;
-    exportCanvas.width = width;
-    exportCanvas.height = height;
-    const context = exportCanvas.getContext("2d");
-    if (!context) return;
+// Waits for the next completed render, then composites every canvas inside
+// #map-div onto one canvas, preserving each layer's opacity and transform.
+export function composeMapCanvas(map) {
+  return new Promise((resolve, reject) => {
+    if (!map) {
+      reject(new Error("There's no map to export."));
+      return;
+    }
 
-    const canvases = document.querySelectorAll("#map-div canvas");
-
-    canvases.forEach((canvas) => {
-      if (!(canvas instanceof HTMLCanvasElement)) return;
-      if (canvas.width === 0 || canvas.height === 0) return;
-
-      const opacity =
-        (canvas.parentElement && canvas.parentElement.style.opacity) || "";
-      context.globalAlpha = opacity === "" ? 1 : Number(opacity);
-
-      const transform = canvas.style.transform;
-      if (transform && transform.startsWith("matrix(")) {
-        const matrix = transform
-          .substring(7, transform.length - 1)
-          .split(",")
-          .map((v) => Number(v.trim()));
-
-        if (matrix.length === 6 && matrix.every((n) => !Number.isNaN(n))) {
-          context.setTransform(
-            matrix[0],
-            matrix[1],
-            matrix[2],
-            matrix[3],
-            matrix[4],
-            matrix[5],
-          );
-        }
-      } else {
-        context.setTransform(1, 0, 0, 1, 0, 0);
+    map.once("rendercomplete", function () {
+      const size = map.getSize();
+      if (!size) {
+        reject(new Error("The map has no size to export."));
+        return;
       }
 
-      context.drawImage(canvas, 0, 0);
+      const exportCanvas = document.createElement("canvas");
+      const [width, height] = size;
+      exportCanvas.width = width;
+      exportCanvas.height = height;
+      const context = exportCanvas.getContext("2d");
+      if (!context) {
+        reject(new Error("Couldn't get a drawing context for the export."));
+        return;
+      }
+
+      const canvases = document.querySelectorAll("#map-div canvas");
+
+      canvases.forEach((canvas) => {
+        if (!(canvas instanceof HTMLCanvasElement)) return;
+        if (canvas.width === 0 || canvas.height === 0) return;
+
+        const opacity =
+          (canvas.parentElement && canvas.parentElement.style.opacity) || "";
+        context.globalAlpha = opacity === "" ? 1 : Number(opacity);
+
+        const transform = canvas.style.transform;
+        if (transform && transform.startsWith("matrix(")) {
+          const matrix = transform
+            .substring(7, transform.length - 1)
+            .split(",")
+            .map((v) => Number(v.trim()));
+
+          if (matrix.length === 6 && matrix.every((n) => !Number.isNaN(n))) {
+            context.setTransform(
+              matrix[0],
+              matrix[1],
+              matrix[2],
+              matrix[3],
+              matrix[4],
+              matrix[5],
+            );
+          }
+        } else {
+          context.setTransform(1, 0, 0, 1, 0, 0);
+        }
+
+        context.drawImage(canvas, 0, 0);
+      });
+
+      context.setTransform(1, 0, 0, 1, 0, 0);
+      context.globalAlpha = 1;
+
+      resolve(exportCanvas);
     });
 
-    context.setTransform(1, 0, 0, 1, 0, 0);
-    context.globalAlpha = 1;
+    map.renderSync();
+  });
+}
 
+function canvasToPngBlob(canvas) {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error("Couldn't encode the map image as a PNG."));
+    }, "image/png");
+  });
+}
+
+// Downloads the composited image. Failures stay silent to the user, as they
+// were before this was promise-based — nothing has visibly started, so there's
+// nothing hanging that needs explaining.
+export async function exportMapImage(map) {
+  try {
+    const canvas = await composeMapCanvas(map);
     const link = document.createElement("a");
-    link.href = exportCanvas.toDataURL("image/png");
+    link.href = canvas.toDataURL("image/png");
     link.download = "atlascope-map.png";
     link.click();
-  });
+  } catch (error) {
+    console.error("Map image export failed:", error);
+  }
+}
 
-  map.renderSync();
+// Uploads the composited image to object storage and resolves with the storage
+// hash plus the share URL built from urlTemplate, whose {hash} placeholder is
+// replaced with the storage key. onUrl fires as soon as the URL is known so
+// the caller can navigate a tab it opened up front — see the popup-blocker
+// note in ExportShareButton. Rejects with a message fit to show a user.
+/**
+ * @param {import("ol").Map} map
+ * @param {string} urlTemplate
+ * @param {{ onUrl?: (url: string) => void }} [options]
+ * @returns {Promise<{ hash: string, url: string }>}
+ */
+export async function uploadMapImage(map, urlTemplate, { onUrl } = {}) {
+  if (!urlTemplate || !urlTemplate.includes("{hash}")) {
+    throw new Error(
+      "this share button has no URL template with a {hash} placeholder.",
+    );
+  }
+
+  const canvas = await composeMapCanvas(map);
+  const blob = await canvasToPngBlob(canvas);
+
+  const signResponse = await fetch(SIGN_ENDPOINT, { method: "POST" });
+  if (!signResponse.ok) {
+    // The function returns a legible message for missing config and blocked
+    // origins; fall back to the status when there's nothing to read.
+    const detail = await signResponse
+      .json()
+      .then((body) => body.error)
+      .catch(() => null);
+    throw new Error(detail || `Couldn't request an upload (${signResponse.status}).`);
+  }
+
+  const { hash, uploadUrl } = await signResponse.json();
+  if (!hash || !uploadUrl) {
+    throw new Error("The upload authorization came back malformed.");
+  }
+
+  const putResponse = await fetch(uploadUrl, {
+    method: "PUT",
+    body: blob,
+    headers: { "Content-Type": "image/png" },
+  });
+  if (!putResponse.ok) {
+    throw new Error(`Storing the map image failed (${putResponse.status}).`);
+  }
+
+  const url = urlTemplate.replaceAll("{hash}", hash);
+  if (onUrl) onUrl(url);
+  return { hash, url };
 }

--- a/src/lib/map/mapActions.js
+++ b/src/lib/map/mapActions.js
@@ -1,6 +1,7 @@
 import { fromLonLat } from "ol/proj";
 import Feature from "ol/Feature";
 import Point from "ol/geom/Point";
+import GeoJSON from "ol/format/GeoJSON";
 
 import { mapState } from "../state.svelte.js";
 import { loadAllmapsLayer } from "./layerSwitching.js";
@@ -11,6 +12,11 @@ import { loadAllmapsLayer } from "./layerSwitching.js";
 // URL-param handling don't lose their request.
 let registered = null;
 let pending = null;
+
+// The dataConnector definition currently rendered on the scratch layer. Kept
+// in module scope (not reactive state) because it carries functions; the UI
+// only needs its name, which lives in mapState.activeDataConnectorName.
+let activeConnector = null;
 
 export function registerMap(instances) {
   registered = instances;
@@ -83,4 +89,62 @@ export function applyMapState({
     rotation: rotation !== null ? rotation : view.getRotation(),
     duration: animate,
   });
+}
+
+// Fetches a dataConnector's GeoJSON for the given bbox ([w,s,e,n] EPSG:4326)
+// and renders its Point features on the scratch layer, replacing whatever was
+// there before. Each feature carries a `_label` (drawn on the map) and a
+// `_targetUrl` (opened from the click popup). Returns the number of points
+// rendered so the caller can report "0 results". Records the connector as the
+// active one so the view-change reload prompt knows what to re-run.
+export async function loadScratchData(connector, bbox) {
+  if (!registered || !bbox) {
+    return 0;
+  }
+  const { scratchSource } = registered;
+  const res = await fetch(connector.queryUrl(bbox));
+  const json = await res.json();
+  const features = new GeoJSON()
+    .readFeatures(json, {
+      dataProjection: "EPSG:4326",
+      featureProjection: "EPSG:3857",
+    })
+    .filter((f) => f.getGeometry()?.getType() === "Point");
+
+  features.forEach((f) => {
+    const props = f.getProperties();
+    // Guard against null/undefined AND whitespace-only labels.
+    const rawLabel = connector.label(props);
+    const label = (typeof rawLabel === "string" ? rawLabel : "").trim();
+    f.set("_label", label || "Unnamed resource");
+    f.set("_targetUrl", connector.targetUrl(props));
+  });
+
+  scratchSource.clear();
+  scratchSource.addFeatures(features);
+
+  activeConnector = connector;
+  mapState.activeDataConnectorName = connector.name;
+  mapState.scratchPointCount = features.length;
+  mapState.scratchReloadAvailable = false;
+
+  return features.length;
+}
+
+// Re-runs the active dataConnector at a new bbox (invoked by the reload
+// prompt). No-op when nothing is loaded.
+export async function reloadScratchData(bbox) {
+  if (!activeConnector) {
+    return 0;
+  }
+  return loadScratchData(activeConnector, bbox);
+}
+
+// Removes all loaded scratch data and dismisses any pending reload prompt.
+export function clearScratchData() {
+  registered?.scratchSource.clear();
+  activeConnector = null;
+  mapState.activeDataConnectorName = null;
+  mapState.scratchPointCount = 0;
+  mapState.scratchReloadAvailable = false;
 }

--- a/src/lib/map/mapActions.js
+++ b/src/lib/map/mapActions.js
@@ -5,6 +5,7 @@ import GeoJSON from "ol/format/GeoJSON";
 
 import { mapState } from "../state.svelte.js";
 import { loadAllmapsLayer } from "./layerSwitching.js";
+import { uploadMapImage } from "./exportImage.js";
 
 // Non-reactive references to the live OpenLayers objects, registered by
 // Map.svelte on mount. A request made before the map exists is held
@@ -40,6 +41,16 @@ export async function loadAllmapsAnnotation(slot, annotation, url) {
   }
   const { warpedLayers, olLayers } = registered;
   await loadAllmapsLayer(warpedLayers, olLayers, slot, annotation, url);
+}
+
+// Uploads the current map view as a PNG and resolves with the share URL built
+// from urlTemplate. Like loadAllmapsAnnotation, this exists so UI components
+// don't have to reach for the live map themselves.
+export async function shareMapImage(urlTemplate, options) {
+  if (!registered) {
+    throw new Error("the map isn't ready yet.");
+  }
+  return uploadMapImage(registered.map, urlTemplate, options);
 }
 
 // Imperatively applies a requested map state: drops a pin, switches

--- a/src/lib/map/mapActions.js
+++ b/src/lib/map/mapActions.js
@@ -102,33 +102,41 @@ export async function loadScratchData(connector, bbox) {
     return 0;
   }
   const { scratchSource } = registered;
-  const res = await fetch(connector.queryUrl(bbox));
-  const json = await res.json();
-  const features = new GeoJSON()
-    .readFeatures(json, {
-      dataProjection: "EPSG:4326",
-      featureProjection: "EPSG:3857",
-    })
-    .filter((f) => f.getGeometry()?.getType() === "Point");
 
-  features.forEach((f) => {
-    const props = f.getProperties();
-    // Guard against null/undefined AND whitespace-only labels.
-    const rawLabel = connector.label(props);
-    const label = (typeof rawLabel === "string" ? rawLabel : "").trim();
-    f.set("_label", label || "Unnamed resource");
-    f.set("_targetUrl", connector.targetUrl(props));
-  });
-
-  scratchSource.clear();
-  scratchSource.addFeatures(features);
-
+  // Surface the badge (with its spinner) immediately, before the request
+  // returns, and disable its buttons until it does.
   activeConnector = connector;
   mapState.activeDataConnectorName = connector.name;
-  mapState.scratchPointCount = features.length;
+  mapState.scratchLoading = true;
   mapState.scratchReloadAvailable = false;
 
-  return features.length;
+  try {
+    const res = await fetch(connector.queryUrl(bbox));
+    const json = await res.json();
+    const features = new GeoJSON()
+      .readFeatures(json, {
+        dataProjection: "EPSG:4326",
+        featureProjection: "EPSG:3857",
+      })
+      .filter((f) => f.getGeometry()?.getType() === "Point");
+
+    features.forEach((f) => {
+      const props = f.getProperties();
+      // Guard against null/undefined AND whitespace-only labels.
+      const rawLabel = connector.label(props);
+      const label = (typeof rawLabel === "string" ? rawLabel : "").trim();
+      f.set("_label", label || "Unnamed resource");
+      f.set("_targetUrl", connector.targetUrl(props));
+    });
+
+    scratchSource.clear();
+    scratchSource.addFeatures(features);
+    mapState.scratchPointCount = features.length;
+
+    return features.length;
+  } finally {
+    mapState.scratchLoading = false;
+  }
 }
 
 // Re-runs the active dataConnector at a new bbox (invoked by the reload
@@ -145,6 +153,7 @@ export function clearScratchData() {
   registered?.scratchSource.clear();
   activeConnector = null;
   mapState.activeDataConnectorName = null;
+  mapState.scratchLoading = false;
   mapState.scratchPointCount = 0;
   mapState.scratchReloadAvailable = false;
 }

--- a/src/lib/mapControls/ControlPanel.svelte
+++ b/src/lib/mapControls/ControlPanel.svelte
@@ -18,7 +18,7 @@
 
   import instanceVariables from "../../config/instance.json";
   import { annotationsEnabled } from "../../config/features.js";
-  import { bboxFunctions } from "../../config/research-connections.js";
+  import { searchConnectors, dataConnectors } from "../../config/research-connections.js";
 
   // The Research tab only appears when the instance gives it content:
   // annotation tools and/or external bbox search links
@@ -31,7 +31,8 @@
     (cg) =>
       cg.id !== "research-controls" ||
       annotationsEnabled ||
-      bboxFunctions.length > 0,
+      searchConnectors.length > 0 ||
+      dataConnectors.length > 0,
   );
 
   let panelShown = $state(null);

--- a/src/lib/mapControls/DataLayerBadge.svelte
+++ b/src/lib/mapControls/DataLayerBadge.svelte
@@ -1,0 +1,68 @@
+<script>
+  // Persistent on-map badge for loaded dataConnector data. Appears as soon as a
+  // query is triggered (showing a spinner + disabled buttons) and switches to
+  // the point count once the request returns. Split into its own component and
+  // lazy-loaded by Map.svelte.
+  import { mapState } from "../state.svelte.js";
+  import { clearScratchData, reloadScratchData } from "../map/mapActions.js";
+
+  let reloadEnabled = $derived(
+    !mapState.scratchLoading && mapState.scratchReloadAvailable,
+  );
+</script>
+
+{#if mapState.activeDataConnectorName}
+  <div
+    class="absolute top-10 left-1/2 -translate-x-1/2 z-20 bg-white/95 text-indigo-900 py-2 px-4 rounded-lg shadow-lg flex flex-col md:flex-row items-center gap-3"
+  >
+    {#if mapState.scratchLoading}
+      <span class="font-semibold text-sm flex items-center gap-2">
+        <svg
+          class="animate-spin h-4 w-4 text-indigo-700"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <circle
+            class="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            stroke-width="4"
+          />
+          <path
+            class="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+          />
+        </svg>
+        Loading data from {mapState.activeDataConnectorName} …
+      </span>
+    {:else}
+      <span class="font-semibold text-sm">
+        {mapState.scratchPointCount} point{mapState.scratchPointCount === 1
+          ? ""
+          : "s"} displayed from {mapState.activeDataConnectorName}
+      </span>
+    {/if}
+
+    <button
+      class="bg-indigo-700 text-white rounded px-3 py-1 text-sm font-semibold hover:bg-indigo-800 cursor-pointer disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed"
+      disabled={mapState.scratchLoading}
+      onclick={() => clearScratchData()}>Clear data</button
+    >
+    <button
+      class="rounded px-3 py-1 text-sm font-semibold {reloadEnabled
+        ? 'bg-indigo-500 text-white hover:bg-indigo-600 cursor-pointer'
+        : 'bg-gray-200 text-gray-400 cursor-not-allowed'}"
+      disabled={!reloadEnabled}
+      onclick={() => reloadScratchData(mapState.extent)}
+      >Reload data for this area</button
+    >
+  </div>
+{/if}
+
+<style>
+</style>

--- a/src/lib/mapControls/ExportShareButton.svelte
+++ b/src/lib/mapControls/ExportShareButton.svelte
@@ -1,0 +1,54 @@
+<script>
+  import { faCamera } from "@fortawesome/free-solid-svg-icons";
+
+  import LightIconButton from "../ui/LightIconButton.svelte";
+  import { shareMapImage } from "../map/mapActions.js";
+
+  // urlTemplate is the outbound URL, with `{hash}` standing in for the stored
+  // image's filename — e.g. "https://example.org/view/{hash}". Drop this
+  // button anywhere with a different template to wire up another service.
+  const {
+    label,
+    urlTemplate,
+    icon = faCamera,
+    busyLabel = "Sharing…",
+    collapsibleLabel = false,
+    hideableOnMobile = false,
+  } = $props();
+
+  let busy = $state(false);
+
+  function share() {
+    if (busy) return;
+    busy = true;
+
+    // The tab has to be opened synchronously, inside the click: by the time
+    // the upload resolves the user-gesture context is gone and popup blockers
+    // reject window.open outright.
+    const tab = window.open("", "_blank");
+
+    shareMapImage(urlTemplate, {
+      onUrl: (url) => {
+        if (tab) tab.location = url;
+        else window.open(url, "_blank");
+      },
+    })
+      .catch((error) => {
+        if (tab) tab.close();
+        console.error("Map image share failed:", error);
+        window.alert(`We're sorry — ${error.message}`);
+      })
+      .finally(() => {
+        busy = false;
+      });
+  }
+</script>
+
+<LightIconButton
+  label={busy ? busyLabel : label}
+  {icon}
+  {collapsibleLabel}
+  {hideableOnMobile}
+  disabled={busy}
+  onclick={share}
+/>

--- a/src/lib/mapControls/MapControls.svelte
+++ b/src/lib/mapControls/MapControls.svelte
@@ -1,6 +1,5 @@
 <script>
     import ViewModeDropupMenu from "./ViewModeDropupMenu.svelte";
-    import ExportShareButton from "./ExportShareButton.svelte";
     import LightIconButton from "../ui/LightIconButton.svelte";
     import Fa from "svelte-fa";
     import { faPlus, faMinus, faRotateRight, faSearchLocation, faLocationArrow, faArrowUp } from "@fortawesome/free-solid-svg-icons";
@@ -81,11 +80,6 @@
             appState.modals.geolocation = true;
           }}
         />
-        <!-- The template must be passed as a JS string, not a bare attribute:
-             Svelte reads `{hash}` in attribute position as an interpolation. -->
-        <ExportShareButton
-          label="Share image"
-          urlTemplate={"https://www.google.com?q={hash}"}
-        />
+
       </div>
 </div>

--- a/src/lib/mapControls/MapControls.svelte
+++ b/src/lib/mapControls/MapControls.svelte
@@ -1,5 +1,6 @@
 <script>
     import ViewModeDropupMenu from "./ViewModeDropupMenu.svelte";
+    import ExportShareButton from "./ExportShareButton.svelte";
     import LightIconButton from "../ui/LightIconButton.svelte";
     import Fa from "svelte-fa";
     import { faPlus, faMinus, faRotateRight, faSearchLocation, faLocationArrow, faArrowUp } from "@fortawesome/free-solid-svg-icons";
@@ -79,6 +80,12 @@
           onclick={() => {
             appState.modals.geolocation = true;
           }}
+        />
+        <!-- The template must be passed as a JS string, not a bare attribute:
+             Svelte reads `{hash}` in attribute position as an interpolation. -->
+        <ExportShareButton
+          label="Share image"
+          urlTemplate={"https://www.google.com?q={hash}"}
         />
       </div>
 </div>

--- a/src/lib/mapControls/ResearchControls.svelte
+++ b/src/lib/mapControls/ResearchControls.svelte
@@ -1,17 +1,43 @@
 <script>
 
   import LightIconButton from "../ui/LightIconButton.svelte";
+  import ResearchDropupMenu from "./ResearchDropupMenu.svelte";
   import { faPenToSquare, faMapPin, faMagnifyingGlassArrowRight } from "@fortawesome/free-solid-svg-icons";
   import { mapState } from "../state.svelte.js";
-  import { bboxFunctions } from "../../config/research-connections.js";
+  import { loadScratchData } from "../map/mapActions.js";
+  import { searchConnectors, dataConnectors } from "../../config/research-connections.js";
   import { annotationsEnabled } from "../../config/features.js";
-  
+
+  // Which dropup menu is open ("search" | "data" | null). Owned here so that
+  // opening one menu closes the other.
+  let openMenu = $state(null);
+  const toggleMenu = (id) => {
+    openMenu = openMenu === id ? null : id;
+  };
+
+  // Opens the external web app for a search connector, using the map extent
+  // (bbox) or center (centerpoint) depending on the connector's queryType.
+  function runSearch(connector) {
+    const geo =
+      connector.queryType === "centerpoint" ? mapState.center : mapState.extent;
+    if (!geo) return;
+    window.open(connector.urlFunction(geo));
+  }
+
+  // Loads a data connector's points onto the scratch layer. Count/clear/reload
+  // are surfaced by the persistent on-map badge, not here.
+  function runLoad(connector) {
+    if (!mapState.extent) return;
+    loadScratchData(connector, mapState.extent);
+  }
+
 </script>
 
 <div>
   <h2 class="md:hidden text-xl font-bold mb-2">Research</h2>
-  <div class="flex flex-wrap">
-    {#if annotationsEnabled}
+
+  {#if annotationsEnabled}
+    <div class="flex flex-wrap mb-2">
       <LightIconButton
         label="Annotate map"
         icon={faPenToSquare}
@@ -26,19 +52,31 @@
           mapState.annotationRead = true;
         }}
       />
+    </div>
+  {/if}
+
+  <div class="flex flex-wrap items-start gap-2">
+    {#if searchConnectors.length > 0}
+      <ResearchDropupMenu
+        triggerLabel="Search this location for …"
+        items={searchConnectors}
+        onSelect={runSearch}
+        icon={faMagnifyingGlassArrowRight}
+        open={openMenu === "search"}
+        onToggle={() => toggleMenu("search")}
+      />
     {/if}
 
-    {#each bboxFunctions as f}
-      <LightIconButton
-        label={f.name}
+    {#if dataConnectors.length > 0}
+      <ResearchDropupMenu
+        triggerLabel="Load data from …"
+        items={dataConnectors}
+        onSelect={runLoad}
         icon={faMagnifyingGlassArrowRight}
-        hideableOnMobile={f.hiddenOnMobile}
-        onclick={() => {
-          let url = f.searchFunction(mapState.extent);
-          window.open(url);
-        }}
+        open={openMenu === "data"}
+        onToggle={() => toggleMenu("data")}
       />
-    {/each}
+    {/if}
   </div>
 </div>
 

--- a/src/lib/mapControls/ResearchControls.svelte
+++ b/src/lib/mapControls/ResearchControls.svelte
@@ -1,11 +1,17 @@
 <script>
-
   import LightIconButton from "../ui/LightIconButton.svelte";
   import ResearchDropupMenu from "./ResearchDropupMenu.svelte";
-  import { faPenToSquare, faMapPin, faMagnifyingGlassArrowRight } from "@fortawesome/free-solid-svg-icons";
+  import {
+    faPenToSquare,
+    faMapPin,
+    faMagnifyingGlassArrowRight,
+  } from "@fortawesome/free-solid-svg-icons";
   import { mapState } from "../state.svelte.js";
   import { loadScratchData } from "../map/mapActions.js";
-  import { searchConnectors, dataConnectors } from "../../config/research-connections.js";
+  import {
+    searchConnectors,
+    dataConnectors,
+  } from "../../config/research-connections.js";
   import { annotationsEnabled } from "../../config/features.js";
 
   // Which dropup menu is open ("search" | "data" | null). Owned here so that
@@ -30,14 +36,13 @@
     if (!mapState.extent) return;
     loadScratchData(connector, mapState.extent);
   }
-
 </script>
 
 <div>
   <h2 class="md:hidden text-xl font-bold mb-2">Research</h2>
 
-  {#if annotationsEnabled}
-    <div class="flex flex-wrap mb-2">
+  <div class="flex flex-wrap items-start gap-2">
+    {#if annotationsEnabled}
       <LightIconButton
         label="Annotate map"
         icon={faPenToSquare}
@@ -52,10 +57,8 @@
           mapState.annotationRead = true;
         }}
       />
-    </div>
-  {/if}
+    {/if}
 
-  <div class="flex flex-wrap items-start gap-2">
     {#if searchConnectors.length > 0}
       <ResearchDropupMenu
         triggerLabel="Search this location for …"

--- a/src/lib/mapControls/ResearchDropupMenu.svelte
+++ b/src/lib/mapControls/ResearchDropupMenu.svelte
@@ -1,0 +1,78 @@
+<script>
+  import Fa from "svelte-fa";
+
+  // Controlled component: the parent owns `open` so opening one menu can close
+  // the other. `onToggle` flips this menu (and closes any sibling); it's also
+  // called after a selection to close the menu.
+  let { triggerLabel, items, onSelect, icon, open = false, onToggle } = $props();
+
+  const handleSelection = (item) => {
+    onSelect(item);
+    onToggle();
+  };
+</script>
+
+<div>
+  <div class="mt-1 relative">
+    <button
+      type="button"
+      onclick={() => onToggle()}
+      class="relative bg-white border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-pointer focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+      aria-haspopup="listbox"
+      aria-expanded={open}
+      aria-labelledby="listbox-label"
+    >
+      <span class="flex items-center">
+        {#if icon}
+          <Fa {icon} class="inline ml-1 mr-2" />
+        {/if}
+        <span class="block text-gray-900 text-lg">{triggerLabel}</span>
+      </span>
+      <span
+        class="ml-3 absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none"
+      >
+        <svg
+          class="h-5 w-5 text-gray-400"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
+            clip-rule="evenodd"
+          />
+        </svg>
+      </span>
+    </button>
+
+    <ul
+      class:hidden={!open}
+      class="absolute bottom-12 z-10 mt-1 bg-white shadow-lg max-h-64 rounded-md py-1 text-base ring-1 ring-black/25 overflow-auto focus:outline-none sm:text-sm"
+      tabindex="-1"
+      role="listbox"
+      aria-labelledby="listbox-label"
+      aria-activedescendant="listbox-option-3"
+    >
+      {#each items as item}
+        <li
+          class="{item.hiddenOnMobile ? 'hidden md:block' : ''} text-gray-800 cursor-pointer select-none relative py-2 pl-3 pr-9 hover:text-red-900"
+          role="option"
+          onclick={() => {
+            handleSelection(item);
+          }}
+        >
+          <div class="flex items-center">
+            <span class="font-normal font-bold ml-1 mr-2 block truncate"
+              >{item.name}</span
+            >
+          </div>
+        </li>
+      {/each}
+    </ul>
+  </div>
+</div>
+
+<style>
+</style>

--- a/src/lib/mapControls/ShareControls.svelte
+++ b/src/lib/mapControls/ShareControls.svelte
@@ -7,6 +7,7 @@
   } from "@fortawesome/free-solid-svg-icons";
 
   import LightIconButton from "../ui/LightIconButton.svelte";
+  import ExportShareButton from "./ExportShareButton.svelte";
 
   let showView = $state(true);
 
@@ -85,9 +86,8 @@
         >
       </div>
     </div>
-
-    {#if navigator.share}
-      <div class="flex flex-wrap mt-2">
+    <div class="flex flex-wrap mt-2">
+      {#if navigator.share}
         <LightIconButton
           label="Share app"
           icon={faMobileAlt}
@@ -102,8 +102,15 @@
             navigator.share({ title: "Atlascope", url: shareURLs.view });
           }}
         />
-      </div>
-    {/if}
+      {/if}
+
+      <!-- The template must be passed as a JS string, not a bare attribute:
+             Svelte reads `{hash}` in attribute position as an interpolation. -->
+      <ExportShareButton
+        label="Save and export"
+        urlTemplate={"https://www.google.com?q={hash}"}
+      />
+    </div>
   </div>
 </div>
 

--- a/src/lib/mapControls/ShareControls.svelte
+++ b/src/lib/mapControls/ShareControls.svelte
@@ -108,7 +108,7 @@
              Svelte reads `{hash}` in attribute position as an interpolation. -->
       <ExportShareButton
         label="Save and export"
-        urlTemplate={"https://www.google.com?q={hash}"}
+        urlTemplate={"https://leventhalmap.donorsupport.co/page/FUNRPRNESZF?image-id={hash}&fundraiseupLivemode=no"}
       />
     </div>
   </div>

--- a/src/lib/mapControls/ShareControls.svelte
+++ b/src/lib/mapControls/ShareControls.svelte
@@ -106,10 +106,12 @@
 
       <!-- The template must be passed as a JS string, not a bare attribute:
              Svelte reads `{hash}` in attribute position as an interpolation. -->
-      <ExportShareButton
+      <!-- <ExportShareButton
         label="Save and export"
         urlTemplate={"https://leventhalmap.donorsupport.co/page/FUNRPRNESZF?image-id={hash}&fundraiseupLivemode=no"}
-      />
+      /> -->
+
+      
     </div>
   </div>
 </div>

--- a/src/lib/state.svelte.js
+++ b/src/lib/state.svelte.js
@@ -41,9 +41,12 @@ export const mapState = $state({
     extent: null,
     rotation: null,
     lockLayers: false,
-    // Name of the dataConnector currently loaded onto the scratch layer (null
-    // when none). Drives the persistent on-map badge.
+    // Name of the dataConnector currently loading or loaded onto the scratch
+    // layer (null when none). Drives the persistent on-map badge.
     activeDataConnectorName: null,
+    // True while a dataConnector query is in flight; the badge shows a spinner
+    // and disables its buttons until the request returns.
+    scratchLoading: false,
     // Number of points currently displayed on the scratch layer.
     scratchPointCount: 0,
     // False immediately after a (re)load; set true on the first map move since,

--- a/src/lib/state.svelte.js
+++ b/src/lib/state.svelte.js
@@ -40,7 +40,15 @@ export const mapState = $state({
     zoom: null,
     extent: null,
     rotation: null,
-    lockLayers: false
+    lockLayers: false,
+    // Name of the dataConnector currently loaded onto the scratch layer (null
+    // when none). Drives the persistent on-map badge.
+    activeDataConnectorName: null,
+    // Number of points currently displayed on the scratch layer.
+    scratchPointCount: 0,
+    // False immediately after a (re)load; set true on the first map move since,
+    // which enables the badge's "reload data for this area" button.
+    scratchReloadAvailable: false
 })
 
 // Layer metadata is a large array of TopoJSON features (geometries included),


### PR DESCRIPTION
## What & why

Reworks the Research tab from a flat row of bbox-search buttons into two dropup menus, and adds a new capability to pull point data onto the map from external APIs.

### 1. "Search this location for …"
The existing outbound-URL connectors, now grouped under one dropup and abstracted so each connector declares a `queryType`:
- `"bbox"` → receives the viewport extent `[w, s, e, n]`
- `"centerpoint"` → receives `[lon, lat]`

### 2. "Load data from …" (new)
Fetches **point** GeoJSON from an external API (e.g. an ArcGIS FeatureServer query with `f=geojson`) and renders it as a scratch layer of "+" markers.
- Each connector supplies `queryUrl(bbox)`, `label(props)`, and `targetUrl(props)`.
- Clicking a point opens a popup whose label links to the target URL (new tab).
- Labels are guarded against null **and** whitespace-only values (fall back to "Unnamed resource").
- Loading replaces any previously loaded data (one set at a time).

### 3. On-map data badge
Loaded data never auto-refreshes on pan/zoom. A persistent round-rect badge floats at the top of the map showing `n points displayed from {source}` with:
- **Clear data** — wipes the layer, badge, and any open popup.
- **Reload data for this area** — disabled right after a (re)load; enables on the first extent change since load, then re-disables after reloading.

### 4. Drag-handle fix
The spyglass drag handle now `preventDefault()`s on mousedown and sets `user-select: none` on the body during a drag, so click-and-drag no longer starts a text selection elsewhere on the page.

## Config / forking
`src/config/research-connections.js` now exports `searchConnectors` and `dataConnectors` (replacing `bboxFunctions`). `FORKING.md` §2 documents the new schema. The Research tab is hidden only when both arrays are empty **and** annotations are disabled.

## Reviewer notes
- Built on OpenLayers; the scratch layer/loader are wired through the existing `mapActions.js` registry (`loadScratchData` / `reloadScratchData` / `clearScratchData`) and a new reusable `ResearchDropupMenu.svelte`.
- The MACRIS `targetUrl` (`mhc-macris.net/details?mhcid=…`) is a placeholder pattern — MACRIS is a JS SPA so the exact detail-page URL wasn't confirmable and should be checked before relying on it.
- Verified end-to-end in the dev preview at Copley Square: load (101 points), popup links, badge count, reload enable/disable cycle, clear, mutually-exclusive dropups, and the drag-handle selection fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)